### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A React plugin that animates your text when it changes.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/TextTransition.js
+++ b/src/components/TextTransition.js
@@ -42,7 +42,7 @@ const TextTransition = ({
 	React.useEffect(() => () => clearTimeout(timeoutId), []);
 
 	return (
-		<animated.div style={ { ...containerStyles, display : inline ? "inline-block" : "block", ...style } } className={ `text-transition ${className}` }>
+		<animated.div style={ { ...containerStyles, whiteSpace: inline ? "nowrap" : "wrap", display : inline ? "inline-block" : "block", ...style } } className={ `text-transition ${className}` }>
 			<span ref={ placeholderRef } className="text-transition_placeholder" />
 			<div className="text-transition_inner" style={ noOverflow ? { overflow : "hidden" } : {} }>
 				{


### PR DESCRIPTION
Changelog:
- Add `whitespace: nowrap` to the container because when the user provides long sentences. The text was being broken into multiple lines which made the width calculation wrong.