### PR TITLE
Hotfix white space has wrong value when the inline prop is false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A React plugin that animates your text when it changes.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/TextTransition.js
+++ b/src/components/TextTransition.js
@@ -42,7 +42,7 @@ const TextTransition = ({
 	React.useEffect(() => () => clearTimeout(timeoutId), []);
 
 	return (
-		<animated.div style={ { ...containerStyles, whiteSpace: inline ? "nowrap" : "wrap", display : inline ? "inline-block" : "block", ...style } } className={ `text-transition ${className}` }>
+		<animated.div style={ { ...containerStyles, whiteSpace: inline ? "nowrap" : "normal", display : inline ? "inline-block" : "block", ...style } } className={ `text-transition ${className}` }>
 			<span ref={ placeholderRef } className="text-transition_placeholder" />
 			<div className="text-transition_inner" style={ noOverflow ? { overflow : "hidden" } : {} }>
 				{


### PR DESCRIPTION
Changelog:
- Change `wrap` to `normal` for `white-space`.