### PR TITLE
Add option to render text immediately on component first render

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const App = () => {
 | noOverflow | Boolean | false | Setting this to true will make the transitioning text appear clipped (Will simply set overflow : hidden on the wrapper). |
 | className | String | "" | Any css classes that you might want to send to the wrapper. |
 | style | Object | {} | Any styles that you might want to send to the wrapper. |
+| immediateOnFirst | Boolean | false | Display the text immediately on the first render |
 
 ___
 
@@ -87,6 +88,8 @@ There're 4 presets
 Any css classes that you might want to provide to the wrapper.
 #### style ```Object```
 Any css styles that you might want to provide to the wrapper.
+#### immediateOnFirst ```Object```
+Setting this to true will display the text immediately on the first render instead of playing the spring animation.
 
 ## NOTE
 Feel free to ask any questions about using this plugin.

--- a/src/components/TextTransition.js
+++ b/src/components/TextTransition.js
@@ -13,17 +13,23 @@ const TextTransition = ({
 	className,
 	style,
 	noOverflow,
-	springConfig
+	springConfig,
+	immediateOnFirst
 }) => {
 	const placeholderRef              = React.useRef(null);
 	const [content, setContent]       = React.useState(() => newText(""));
 	const [timeoutId, setTimeoutId]   = React.useState(0);
+	const [isFirstRun, setIsFirstRun] = React.useState(true);
 	const [containerStyles, setWidth] = useSpring(() => ({ to : { width : inline ? 0 : "auto" }, config : springConfig }));
 	const transitions                 = useTransition(content, (item) => item.key, {
-		from   : { opacity : 0, transform : `translateY(${direction === "down" ? "-100%" : "100%"})` },
-		enter  : { opacity : 1, transform : "translateY(0%)" },
-		leave  : { opacity : 0, transform : `translateY(${direction === "down" ? "100%" : "-100%"})` },
-		config : springConfig
+		from        : { opacity : 0, transform : `translateY(${direction === "down" ? "-100%" : "100%"})` },
+		enter       : { opacity : 1, transform : "translateY(0%)" },
+		leave       : { opacity : 0, transform : `translateY(${direction === "down" ? "100%" : "-100%"})` },
+		config      : springConfig,
+		immediate   : immediateOnFirst && isFirstRun,
+		onDestroyed : () => {
+			setIsFirstRun(false);
+		}
 	});
 	React.useEffect(() => {
 		setTimeoutId(
@@ -73,24 +79,26 @@ const TextTransition = ({
 };
 
 TextTransition.propTypes = {
-	text         : PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-	direction    : PropTypes.oneOf(["up", "down"]),
-	inline       : PropTypes.bool,
-	noOverflow   : PropTypes.bool,
-	delay        : PropTypes.number,
-	className    : PropTypes.string,
-	style        : PropTypes.object,
-	springConfig : PropTypes.any
+	text             : PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+	direction        : PropTypes.oneOf(["up", "down"]),
+	inline           : PropTypes.bool,
+	noOverflow       : PropTypes.bool,
+	delay            : PropTypes.number,
+	className        : PropTypes.string,
+	style            : PropTypes.object,
+	springConfig     : PropTypes.any,
+	immediateOnFirst : PropTypes.bool
 };
 
 TextTransition.defaultProps = {
-	direction    : "up",
-	noOverflow   : false,
-	inline       : false,
-	springConfig : config.default,
-	delay        : 0,
-	className    : "",
-	style        : {}
+	direction        : "up",
+	noOverflow       : false,
+	inline           : false,
+	springConfig     : config.default,
+	delay            : 0,
+	className        : "",
+	style            : {},
+	immediateOnFirst : false
 };
 
 export default TextTransition;


### PR DESCRIPTION
Add `immediateOnFirst` prop. When set to `true` the provided text will render immediately instead of displaying the spring animation. (see the attachment below)

https://user-images.githubusercontent.com/28344318/106163133-6cf97b00-61bb-11eb-94f9-839b6d18ba74.mov

Demo on [CodeSandbox](https://codesandbox.io/s/react-text-transition-forked-3nblb)