### PR TITLE
Docs: fix array index typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const App = () => {
   return (
     <h1>
       <TextTransition springConfig={presets.wobbly}>
-        {TEXTS[index % TEXTS.length}
+        {TEXTS[index % TEXTS.length]}
       </TextTransition>
     </h1>
   );


### PR DESCRIPTION
Added a small fix to the README (`TEXTS` index access missing a closing square bracket).