### PR TITLE
feat: refactor using `@react-sping/web` and remove prop-types usage

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  bracketSpacing: true,
+  printWidth: 100,
+  singleQuote: true,
+  trailingComma: 'all',
+  arrowParens: 'always',
+  // For wrapping text in .md and .mdx files
+  proseWrap: 'always',
+};

--- a/README.md
+++ b/README.md
@@ -1,90 +1,104 @@
 # React-Text-transition
+
 ### Animate your text changes
 
 ![text-transition](https://raw.githubusercontent.com/WinterCore/react-text-transition/master/example-gifs/example.gif)
 
 [![Edit r03264p26n](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/r03264p26n?view=preview)
+
 ## Installation
-```npm install -S react-text-transition```
+
+`npm install -S react-text-transition`
+
 ## Using the demo
-```npm run dev```
+
+`npm run dev`
+
 ## How to use
 
 ### Example
-```javascript
-import React                       from "react";
-import TextTransition, { presets } from "react-text-transition";
 
-const TEXTS = [
-  "Forest",
-  "Building",
-  "Tree",
-  "Color"
-];
+```javascript
+import React from 'react';
+import TextTransition, { presets } from 'react-text-transition';
+
+const TEXTS = ['Forest', 'Building', 'Tree', 'Color'];
 
 const App = () => {
   const [index, setIndex] = React.useState(0);
 
   React.useEffect(() => {
-    const intervalId = setInterval(() =>
-      setIndex(index => index + 1),
-      3000 // every 3 seconds
+    const intervalId = setInterval(
+      () => setIndex((index) => index + 1),
+      3000, // every 3 seconds
     );
     return () => clearTimeout(intervalId);
   }, []);
 
   return (
     <h1>
-      <TextTransition springConfig={presets.wobbly}>
-        {TEXTS[index % TEXTS.length]}
-      </TextTransition>
+      <TextTransition springConfig={presets.wobbly}>{TEXTS[index % TEXTS.length]}</TextTransition>
     </h1>
   );
 };
 ```
 
 ### Props
-| Prop | Type | Default | Definition |
-| --- | --- | --- | --- |
-| text | String | REQUIRED | The text you want to show. |
-| direction | String (enum) | 0 | Used to determine the direction of the transition `"up"` or `"down"` (Must be an all-lowercase string). |
-| inline | Boolean | false | Makes the wrapper inline (will auto resize based on contents). |
-| delay | Number | 0 | Delay the transition of the text (in milliseconds). |
-| springConfig | Object | { mass: 1, tension: 170, friction: 26 } | react-spring's spring configuration. |
-| className | String | "" | Any css classes that you might want to send to the wrapper. |
-| style | React.CSSProperties | {} | Any styles that you might want to send to the wrapper. |
-| children | React.ReactNode | REQUIRED | The react node to be animated |
 
-___
+| Prop         | Type                | Default                                 | Definition                                                                                              |
+| ------------ | ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| direction    | String (enum)       | 0                                       | Used to determine the direction of the transition `"up"` or `"down"` (Must be an all-lowercase string). |
+| inline       | Boolean             | false                                   | Makes the wrapper inline (will auto resize based on contents).                                          |
+| delay        | Number              | 0                                       | Delay the transition of the text (in milliseconds).                                                     |
+| springConfig | Object              | { mass: 1, tension: 170, friction: 26 } | react-spring's spring configuration.                                                                    |
+| className    | String              | ""                                      | Any css classes that you might want to send to the wrapper.                                             |
+| style        | React.CSSProperties | {}                                      | Any styles that you might want to send to the wrapper.                                                  |
+| children     | React.ReactNode     | REQUIRED                                | The react node to be animated                                                                           |
+| translateValue     | string     | "100%"                                | Transform value for determine height animation                                                                           |
+
+---
 
 ### Detailed Props
-#### inline ```Boolean```
-Will simply make the wrapper an inline element and animate its width based on currently showing text, this is useful if you want to show some other static text on the same line.
-#### delay ```Number```
-The amount of miliseconds to wait before transitioning.
-#### spring ```Object```
-react-spring's [Spring configuration](https://www.react-spring.io/docs/hooks/api) (Refer to the configs section)
-react-spring's spring presets are exposed as `presets`.
-```javascript
-  import TextTransition, { presets } from "react-text-transition";
 
-  // in your render method
-  <TextTransition springConfig={presets.wobbly}>
-    {this.state.text}
-  </TextTransition>
+#### inline `Boolean`
+
+Will simply make the wrapper an inline element and animate its width based on currently showing
+text, this is useful if you want to show some other static text on the same line.
+
+#### delay `Number`
+
+The amount of miliseconds to wait before transitioning.
+
+#### spring `Object`
+
+react-spring's [Spring configuration](https://www.react-spring.io/docs/hooks/api) (Refer to the
+configs section) react-spring's spring presets are exposed as `presets`.
+
+```javascript
+import TextTransition, { presets } from 'react-text-transition';
+
+// in your render method
+<TextTransition springConfig={presets.wobbly}>{this.state.text}</TextTransition>;
 ```
+
 There're 4 presets
-* ```default``` The default.
-* ```gentle```
-* ```wobbly```
-* ```stiff```
-* ```slow```
-* ```molasses```
-#### className ```String```
+
+- `default` The default.
+- `gentle`
+- `wobbly`
+- `stiff`
+- `slow`
+- `molasses`
+
+#### className `String`
+
 Any css classes that you might want to provide to the wrapper.
-#### style ```React.CSSProperties```
+
+#### style `React.CSSProperties`
+
 Any css styles that you might want to provide to the wrapper.
 
 ## NOTE
-Feel free to ask any questions about using this component.
-This plugin requires [react](https://www.npmjs.com/package/react) +16.8
+
+Feel free to ask any questions about using this component. This plugin requires
+[react](https://www.npmjs.com/package/react) +16.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "3.0.2",
+  "version": "4.0.0-alpha.1",
   "description": "A React plugin that animates your text when it changes.",
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",
@@ -46,7 +46,7 @@
     "webpack-dev-server": "^4.9.2"
   },
   "dependencies": {
-    "react-spring": "^9.4.5"
+    "@react-spring/web": "^9.7.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "4.0.0-alpha.1",
+  "version": "3.1.0-beta.1",
   "description": "A React plugin that animates your text when it changes.",
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/src/components/TextTransition.tsx
+++ b/src/components/TextTransition.tsx
@@ -4,11 +4,11 @@ import type { CSSProperties, PropsWithChildren } from 'react';
 import { useSpring, useTransition, animated, config, SpringConfig } from '@react-spring/web';
 
 export interface TextTransitionProps {
+  className?: string;
+  delay?: number;
   direction?: 'up' | 'down';
   inline?: boolean;
   springConfig?: SpringConfig;
-  delay?: number;
-  className?: string;
   style?: CSSProperties;
   translateValue?: string;
 }

--- a/src/components/TextTransition.tsx
+++ b/src/components/TextTransition.tsx
@@ -1,92 +1,91 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React, { useState, useRef, useEffect } from 'react';
+import type { CSSProperties, PropsWithChildren } from 'react';
 
-import {useSpring, useTransition, animated, config, SpringConfig} from "react-spring";
+import { useSpring, useTransition, animated, config, SpringConfig } from '@react-spring/web';
 
-const TextTransition: React.FC<TextTransitionProps> = (props) => {
-    const {
-        direction = "up",
-        inline = false,
-        springConfig = config.default,
-		delay = 0,
-        className,
-        style,
-        children,
-    } = props;
-
-    const initialRun = React.useRef(true);
-
-	const transitions = useTransition([children], {
-		from: { opacity : 0, transform : `translateY(${direction === "down" ? "-100%" : "100%"})` },
-		enter: { opacity : 1, transform : "translateY(0%)" },
-		leave: { opacity : 0, transform : `translateY(${direction === "down" ? "100%" : "-100%"})`, position: "absolute" },
-		config: springConfig,
-        immediate: initialRun.current,
-		delay: ! initialRun.current ? delay : undefined,
-	});
-
-    const [width, setWidth] = React.useState<number>(0);
-    const currentRef = React.useRef<HTMLDivElement>(null);
-	const heightRef = React.useRef<number | string>("auto");
-
-    React.useEffect(() => {
-        initialRun.current = false;
-
-        const elem = currentRef.current;
-
-        if (! elem) {
-            return;
-        }
-        
-        const { width, height } = elem.getBoundingClientRect();
-        setWidth(width);
-		heightRef.current = height;
-    }, [children, setWidth, currentRef]);
-
-    const widthTransition = useSpring({
-		to: { width },
-		config: springConfig,
-        immediate: initialRun.current,
-		delay: ! initialRun.current ? delay : undefined,
-	});
-
-	return (
-		<animated.div
-			className={`text-transition ${className}`}
-			style={{
-                ...(inline && ! initialRun.current ? widthTransition : undefined),
-				...style,
-				whiteSpace: inline ? "nowrap" : "normal",
-				display: inline ? "inline-flex" : "flex",
-				height: heightRef.current,
-			}}
-		>
-            {transitions((styles, item) =>
-                <animated.div style={{ ...styles }}
-                              ref={item === children ? currentRef : undefined}
-                              children={item} />
-            )}
-		</animated.div>
-	);
-};
-
-interface TextTransitionProps {
-	readonly direction?: "up" | "down";
-	readonly inline?: boolean;
-	readonly delay?: number;
-	readonly springConfig?: SpringConfig;
-	readonly className?: string;
-	readonly style?: React.CSSProperties;
-    readonly children: React.ReactNode;
+export interface TextTransitionProps {
+  direction?: 'up' | 'down';
+  inline?: boolean;
+  springConfig?: SpringConfig;
+  delay?: number;
+  className?: string;
+  style?: CSSProperties;
+  translateValue?: string;
 }
 
-TextTransition.propTypes = {
-	direction: PropTypes.oneOf(["up", "down"]),
-	inline: PropTypes.bool,
-	delay: PropTypes.number,
-	className: PropTypes.string,
-	style: PropTypes.object,
-	springConfig: PropTypes.any,
-};
+function TextTransition(props: PropsWithChildren<TextTransitionProps>) {
+  const {
+    direction = 'up',
+    inline = false,
+    springConfig = config.default,
+    delay = 0,
+    className,
+    style,
+    translateValue: tv = '100%',
+    children,
+  } = props;
+
+  const initialRun = useRef(true);
+  const fromTransform = direction === 'down' ? `-${tv}` : tv;
+  const leaveTransform = direction === 'down' ? tv : `-${tv}`;
+
+  const transitions = useTransition([children], {
+    enter: { opacity: 1, transform: 'translateY(0%)' },
+    from: { opacity: 0, transform: `translateY(${fromTransform})` },
+    leave: {
+      opacity: 0,
+      transform: `translateY(${leaveTransform})`,
+      position: 'absolute',
+    },
+    config: springConfig,
+    immediate: initialRun.current,
+    delay: !initialRun.current ? delay : undefined,
+  });
+
+  const [width, setWidth] = useState<number>(0);
+  const currentRef = useRef<HTMLDivElement>(null);
+  const heightRef = useRef<number | string>('auto');
+
+  useEffect(() => {
+    initialRun.current = false;
+    const element = currentRef.current;
+
+    // If element doesn't exist, then do nothing
+    if (!element) return;
+
+    const { width, height } = element.getBoundingClientRect();
+
+    setWidth(width);
+    heightRef.current = height;
+  }, [children, setWidth, currentRef]);
+
+  const widthTransition = useSpring({
+    to: { width },
+    config: springConfig,
+    immediate: initialRun.current,
+    delay: !initialRun.current ? delay : undefined,
+  });
+
+  return (
+    <animated.div
+      className={`text-transition ${className}`}
+      style={{
+        ...(inline && !initialRun.current ? widthTransition : undefined),
+        ...style,
+        whiteSpace: inline ? 'nowrap' : 'normal',
+        display: inline ? 'inline-flex' : 'flex',
+        height: heightRef.current,
+      }}
+    >
+      {transitions((styles, item) => (
+        <animated.div
+          style={{ ...styles }}
+          ref={item === children ? currentRef : undefined}
+          children={item}
+        />
+      ))}
+    </animated.div>
+  );
+}
 
 export default TextTransition;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
-import { config } from "react-spring";
+import { config } from "@react-spring/web";
 
-import TextTransition from "./components/TextTransition";
+import TextTransition, {
+  TextTransitionProps,
+} from "./components/TextTransition";
 
-export default TextTransition;
 export { config as presets };
+export type { TextTransitionProps };
+export default TextTransition;

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,91 +168,51 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-spring/animated@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.5.tgz#dd9921c716a4f4a3ed29491e0c0c9f8ca0eb1a54"
-  integrity sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==
+"@react-spring/animated@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.2.tgz#0119db8075e91d693ec45c42575541e01b104a70"
+  integrity sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==
   dependencies:
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/core@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.4.5.tgz#4616e1adc18dd10f5731f100ebdbe9518b89ba3c"
-  integrity sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==
+"@react-spring/core@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.2.tgz#804ebadee45a6adff00886454d6f1c5d97ee219d"
+  integrity sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==
   dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/rafz" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/animated" "~9.7.2"
+    "@react-spring/rafz" "~9.7.2"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/konva@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.4.5.tgz#28e6f6e0dfb7f7a93c6ba4f91295f3f7d5557f06"
-  integrity sha512-b3wTs7YT5102+Gs488r2JCNBoyZQd+SWg35AdxmiI6FARBFvBjIA0z7VJx8ILAlmTVBows5UwiDWvk2vmWmLLw==
+"@react-spring/rafz@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.2.tgz#77e7088c215e05cf893851cd87ceb40d89f2a7d7"
+  integrity sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A==
+
+"@react-spring/shared@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.2.tgz#b8485617bdcc9f6348b245922051fb534e07c566"
+  integrity sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==
   dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/rafz" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/native@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.4.5.tgz#c8ec950cae02eb28a0246b912df844f526aab64c"
-  integrity sha512-11GcqFZfIhOOVQI25FcDLdeJLOSVOgIh2AF6WMXpCNWguhIv6N33zLL8d4cYfhYhsLOVXprU/8uefNorj7/h3g==
+"@react-spring/types@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.2.tgz#e04dd72755d88b0e3163ba143ecd8ba78b68a5b0"
+  integrity sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g==
+
+"@react-spring/web@^9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.2.tgz#76e53dd24033764c3062f9927f88b0f3194688d4"
+  integrity sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==
   dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
-
-"@react-spring/rafz@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.4.5.tgz#84f809f287f2a66bbfbc66195db340482f886bd7"
-  integrity sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ==
-
-"@react-spring/shared@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.4.5.tgz#4c3ad817bca547984fb1539204d752a412a6d829"
-  integrity sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==
-  dependencies:
-    "@react-spring/rafz" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
-
-"@react-spring/three@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.4.5.tgz#bd5b7844fde3338b05920654d81f127a5760f057"
-  integrity sha512-mArxfIhg9kyFL/8Y09TarS/ZKLd/qAWS4T3Ro/B46ILPfPnoPywDdw9/rknZihy/tslnviCgMrB4pZ29X1Dfxw==
-  dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
-
-"@react-spring/types@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.5.tgz#9c71e5ff866b5484a7ef3db822bf6c10e77bdd8c"
-  integrity sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg==
-
-"@react-spring/web@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.4.5.tgz#b92f05b87cdc0963a59ee149e677dcaff09f680e"
-  integrity sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==
-  dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
-
-"@react-spring/zdog@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.4.5.tgz#66e35db08f93a0ef949f1fa1303513157c450f91"
-  integrity sha512-STrePM34ZK1T3oK8mo71pvKxvIzELJTpVi0U0qDh0s15e9rmN6XYkd406LqFtuchhmLoy24lD4ds7LAqhIEraw==
-  dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/animated" "~9.7.2"
+    "@react-spring/core" "~9.7.2"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -2068,18 +2028,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-spring@^9.4.5:
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.4.5.tgz#a2a56e72a7ad5075af4ee606f0b2ca9ee2474df0"
-  integrity sha512-FRIXQGR+jG+Fx4UcqhF0b5jMEU3Q5QcZ8rEVWKqZgrrn92C1HcqtuZy7dH+rZ6uNGjnlV7HBf8iprJaJ+350LA==
-  dependencies:
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/konva" "~9.4.5"
-    "@react-spring/native" "~9.4.5"
-    "@react-spring/three" "~9.4.5"
-    "@react-spring/web" "~9.4.5"
-    "@react-spring/zdog" "~9.4.5"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
### Brief

Hello @WinterCore 👋 First of all, thank you for creating this awesome package. I'm using your package for year now and working smoothly until I'm upgraded my project to Next.js 13.x.x in the beginning of the year. In development, I don't see any error but when I built my PR and deployed, I found the issue because `prop-types` no longer support in `Next.js@v13` TypeScript. 

So, I decided to re-create this component in my local component by use interface instead of using `prop-types` and also use the latest package recommendation from `@react-spring` https://www.react-spring.dev/docs/getting-started. It's working perfectly! 😄  
 
I'm super excited to share my latest changes in this pull request! These changes include refactoring main component, adding `.prettierc.js` and also updating `README.md`. I've also tested these changes thoroughly to ensure they meet our project's high standards for quality and performance. Thank you for taking the time to review my work, and I look forward to your feedback!

### Notable Changes
- [x] use latest package recommendation `@react-spring/web`
- [x] update package.json version to beta
- [x] export interface `TextTransitionProps`
- [x] update readme.md
- [x] remove `prop-types` usage
- [x] add `.prettierrc.js` 

### Result

Codesanbox Link: https://codesandbox.io/p/sandbox/react-text-transition-improvement-q268i9?file=README.md

https://user-images.githubusercontent.com/10141928/230700196-95700d51-ad67-472b-8377-ace9c334ff17.mov


Local Development Proof

https://user-images.githubusercontent.com/10141928/230700225-5abffe53-6069-4c01-8278-5f0ed54a5919.mov


