### PR TITLE
chore: bump to `v3.1.0` ⚡️

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![text-transition](https://raw.githubusercontent.com/WinterCore/react-text-transition/master/example-gifs/example.gif)
 
-[![Edit r03264p26n](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/r03264p26n?view=preview)
+[![Edit r03264p26n](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-text-transition-ts-6wp1s7?file=/src/components/App.tsx)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-transition",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0",
   "description": "A React plugin that animates your text when it changes.",
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",


### PR DESCRIPTION
### Brief

Hi @WinterCore 👋
Since the `3.1.0-beta.1` was released and no issue, I want to remove the beta tag now and release as stable version in `v3.1.0`. I'm also update the codesanbox link demo with latest package, Thank you!

## Detail Task

Bump React Text Transition to stable version with `v3.1.0` and update codesanbox.

## Notable Changes

- [x] Remove beta tag, and bump to `v3.1.0`
- [x] Update Codesanbox Link