### PR TITLE
Recalculate element width/height on window resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "webpack-dev-server": "^4.9.2"
   },
   "dependencies": {
-    "@react-spring/web": "^9.7.2"
+    "@react-spring/web": "^9.7.2",
+    "use-debounce": "^9.0.4"
   },
   "peerDependencies": {
     "react": ">=18.0.0"


### PR DESCRIPTION
Hi,

I believe this addresses #32 and fixes the element sizing when the window is resized.

To keep it performant, I've added the `use-debounce` package, defaulted the debounce to `50ms` and added an option for users to configure the debounce if required.

Tested on my website and seems to have resolved the odd sizing when I played with the window size and the font changes size between different breakpoints.

Thanks 👍